### PR TITLE
Cambio CSS, todo azul a naranja

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -45,7 +45,7 @@ p {
 /* Button */
 
 .button_di-buffala {
-  background-color: #325DFF;
+  background-color: #ff9743e3;
   border-radius: 30px;
   padding: 2rem 6rem;
   color: #fff;
@@ -54,15 +54,15 @@ p {
 }
 
 .button_di-buffala:hover {
-  background-color: hsla(227, 100%, 60%, .1);
-  color: #325DFF;
+  background-color: hsla(36, 63%, 22%, 0.1);
+  color: #ff9743e3;
 }
 
 /* Navbar */
 
 .navbar_di-buffala {
-  background-color: #325DFF;
-  color: hsla(0, 100%, 100%, 0.52);
+  background-color: #ff9743e3;
+  color: hsla(0, 100%, 98%, 0.942);
 }
 .icon-bar {
   background-color: #fff;
@@ -197,7 +197,7 @@ p {
 }
 
 .features__inner-icon {
-  background-color: #325DFF;
+  background-color: #ff9743e3;
   border-radius: 50%;
   width: 100px;
   height: 100px;
@@ -378,7 +378,7 @@ p {
 
 
 .footer_di-buffala {
-  background-color: #325DFF;
+  background-color: #ff9743e3;
   padding: 5vw 1rem;
   text-align: center;
 }


### PR DESCRIPTION
Los colores azules en CSS fueron cambiados a naranjas en toda la página.