### PR TITLE
Portfolio section_Ajustes Pantallas <767px_img background, ajustes font

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -374,6 +374,36 @@ p {
 
 }
 
+@media only screen and (max-width : 767px){
+  .portfolio_bkg_top{
+    background-image: url(../img/portfolio-1.jpg);
+    background-repeat: no-repeat;
+    background-position: center;
+    color: #325DFF;
+    font-style: oblique;
+  }
+
+  .portfolio_bkg_middle{
+    background-image: url(../img/portfolio-2.jpg);
+    background-repeat: no-repeat;
+    background-position: center;
+    color: #325DFF;
+    font-style: oblique;
+  }
+
+  .portfolio_bkg_bottom{
+    background-image: url(../img/portfolio-3.jpg);
+    background-repeat: no-repeat;
+    background-position: center;
+    color: #325DFF;
+    font-style: oblique;
+  }
+
+
+}
+
+
+
 /* Footer */
 
 

--- a/index.html
+++ b/index.html
@@ -141,7 +141,7 @@
     <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras ultrices accumsan ornare. Phasellus tristique ullamcorper luctus. Nunc varius ullamcorper felis. Nulla nibh ipsum, rutrum.</p>
     <hr>
     <div class="row">
-      <div class="portfolio__inner col-md-6">
+      <div class="portfolio__inner col-md-6 portfolio_bkg_top">
         <h3>Lorem ipsum dolor sit amet, consectetur adipiscing elit. </h3>
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras ultrices accumsan ornare. Phasellus tristique ullamcorper luctus.</p>
         <a class="btn button_di-buffala" href="#">Ver trabajo</a>
@@ -149,13 +149,13 @@
       <div class="portfolio__inner portfolio__inner__image-top col-md-6"></div>
 
       <div class="portfolio__inner portfolio__inner__image-middle col-md-6"></div>
-      <div class="portfolio__inner col-md-6">
+      <div class="portfolio__inner col-md-6 portfolio_bkg_middle">
         <h3>Lorem ipsum dolor sit amet, consectetur adipiscing elit. </h3>
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras ultrices accumsan ornare. Phasellus tristique ullamcorper luctus.</p>
         <a class="btn button_di-buffala" href="#">Ver trabajo</a>
       </div>
 
-      <div class="portfolio__inner col-md-6">
+      <div class="portfolio__inner col-md-6 portfolio_bkg_bottom">
         <h3>Lorem ipsum dolor sit amet, consectetur adipiscing elit. </h3>
         <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras ultrices accumsan ornare. Phasellus tristique ullamcorper luctus.</p>
         <a class="btn button_di-buffala" href="#">Ver trabajo</a>


### PR DESCRIPTION
Se realizaron cambios solo en la "Portfolio Section", donde al notar que en pantallas con tamaño menor a 767px las imágenes relacionadas a los "trabajos" desaparecían, por ende perdiendo contenido valioso para un usuario. De esta manera se agregaron las imágenes como background al div que contiene todo el contenido, y además se realizó un pequeño ajuste de los fonts (cambio de color y se dejó en coursiva).
![Captura de pantalla 2024-03-26 122757](https://github.com/heltonsmith/Landing/assets/161616446/b49aa169-e3f8-4da1-b35f-05dd982a8b00)
